### PR TITLE
Use Query instead of Selector

### DIFF
--- a/src/Test/Html/Internal/ElmHtml/Query.elm
+++ b/src/Test/Html/Internal/ElmHtml/Query.elm
@@ -29,9 +29,7 @@ import Test.Html.Internal.ElmHtml.InternalTypes exposing (..)
 type Selector
     = Id String
     | ClassName String
-    | ClassNameNS String
     | ClassList (List String)
-    | ClassListNS (List String)
     | Tag String
     | Attribute String String
     | BoolAttribute String Bool
@@ -241,22 +239,12 @@ hasBoolAttribute attribute value facts =
 
 hasClass : String -> Facts msg -> Bool
 hasClass queryString facts =
-    List.member queryString (classnames facts)
-
-
-hasClassNS : String -> Facts msg -> Bool
-hasClassNS queryString facts =
-    List.member queryString (classnamesNS facts)
+    List.member queryString (classnames facts ++ classes facts)
 
 
 hasClasses : List String -> Facts msg -> Bool
 hasClasses classList facts =
-    containsAll classList (classnames facts)
-
-
-hasClassesNS : List String -> Facts msg -> Bool
-hasClassesNS classList facts =
-    containsAll classList (classnamesNS facts)
+    containsAll classList (classnames facts ++ classes facts)
 
 
 hasStyle : { key : String, value : String } -> Facts msg -> Bool
@@ -271,8 +259,8 @@ classnames facts =
         |> String.split " "
 
 
-classnamesNS : Facts msg -> List String
-classnamesNS facts =
+classes : Facts msg -> List String
+classes facts =
     Dict.get "class" facts.stringAttributes
         |> Maybe.withDefault ""
         |> String.split " "
@@ -296,17 +284,9 @@ nodeRecordPredicate selector =
             .facts
                 >> hasClass classname
 
-        ClassNameNS classname ->
-            .facts
-                >> hasClassNS classname
-
         ClassList classList ->
             .facts
                 >> hasClasses classList
-
-        ClassListNS classList ->
-            .facts
-                >> hasClassesNS classList
 
         Tag tag ->
             .tag
@@ -343,17 +323,9 @@ markdownPredicate selector =
             .facts
                 >> hasClass classname
 
-        ClassNameNS classname ->
-            .facts
-                >> hasClassNS classname
-
         ClassList classList ->
             .facts
                 >> hasClasses classList
-
-        ClassListNS classList ->
-            .facts
-                >> hasClassesNS classList
 
         Tag tag ->
             always False

--- a/src/Test/Html/Selector.elm
+++ b/src/Test/Html/Selector.elm
@@ -1,7 +1,7 @@
 module Test.Html.Selector exposing
     ( Selector
     , tag, text, containing, attribute, all
-    , id, class, classNS, classes, classesNS, exactClassName, exactClassNameNS, style, checked, selected, disabled
+    , id, class, classes, exactClassName, style, checked, selected, disabled
     )
 
 {-| Selecting HTML elements.
@@ -16,7 +16,7 @@ module Test.Html.Selector exposing
 
 ## Attributes
 
-@docs id, class, classNS, classes, classesNS, exactClassName, exactClassNameNS, style, checked, selected, disabled
+@docs id, class, classes, exactClassName, style, checked, selected, disabled
 
 -}
 
@@ -85,32 +85,6 @@ classes =
     Classes
 
 
-{-| Matches svg elements that have all the given classes (and possibly others as well).
-
-When you only care about one class instead of several, you can use
-[`classNS`](#classNS) instead of passing this function a list with one value in it.
-
-To match the element's exact class attribute string, use [`exactClassNameNS`](#exactClassNameNS).
-
-    import Svg.Html as SvgHtml
-    import Svg.Attributes as SvgAttr
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (classesNS)
-
-
-    test "Svg has the classes svg-styles and svg-large" <|
-        \() ->
-            SvgHtml.svg [ SvgAttr.class "svg-styles svg-large" ] []
-                |> Query.fromHtml
-                |> Query.has [ classesNS [ "svg-styles", "svg-large" ] ]
-
--}
-classesNS : List String -> Selector
-classesNS =
-    ClassesNS
-
-
 {-| Matches elements that have the given class (and possibly others as well).
 
 To match multiple classes at once, use [`classes`](#classes) instead.
@@ -136,36 +110,11 @@ class =
     Class
 
 
-{-| Matches svg elements that have the given class (and possibly others as well).
-
-To match multiple classes at once, use [`classesNS`](#classesNS) instead.
-
-To match the element's exact class attribute string, use [`exactClassNameNS`](#exactClassNameNS).
-
-    import Svg.Html as SvgHtml
-    import Svg.Attributes as SvgAttr
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (classNS)
-
-
-    test "Svg has the class svg-large" <|
-        \() ->
-            SvgHtml.svg [ SvgAttr.class "svg-styles svg-large" ] [  ]
-                |> Query.fromHtml
-                |> Query.has [ classNS "svg-large" ]
-
--}
-classNS : String -> Selector
-classNS =
-    ClassNS
-
-
-{-| Matches the element's exact class attribute string.
+{-| Matches the element's exact "className" property string.
 
 This is used less often than [`class`](#class), [`classes`](#classes) or
 [`attribute`](#attribute), which check for the _presence_ of a class as opposed
-to matching the entire class attribute exactly.
+to matching the entire class property exactly.
 
     import Html
     import Html.Attributes as Attr
@@ -180,35 +129,12 @@ to matching the entire class attribute exactly.
                 |> Query.fromHtml
                 |> Query.has [ exactClassName "btn btn-large" ]
 
+There's a difference between properties and attributes (read more [here](https://github.com/elm/html/blob/master/properties-vs-attributes.md)).
+
 -}
 exactClassName : String -> Selector
 exactClassName =
     namedAttr "className"
-
-
-{-| Matches the svg element's exact class attribute string.
-
-This is used less often than [`classNS`](#classNS) or [`classesNS`](#classesNS),
-which check for the _presence_ of a class as opposed to matching the entire
-class attribute exactly.
-
-    import Svg.Html as SvgHtml
-    import Svg.Attributes as SvgAttr
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (exactClassNameNS)
-
-
-    test "Svg has the exact class 'svg-styles svg-large'" <|
-        \() ->
-            SvgHtml.svg [ SvgAttr.class "btn btn-large" ] []
-                |> Query.fromHtml
-                |> Query.has [ exactClassNameNS "svg-styles svg-large" ]
-
--}
-exactClassNameNS : String -> Selector
-exactClassNameNS =
-    namedAttr "class"
 
 
 {-| Matches elements that have the given `id` attribute.

--- a/src/Test/Html/Selector/Internal.elm
+++ b/src/Test/Html/Selector/Internal.elm
@@ -7,9 +7,7 @@ import Test.Html.Internal.ElmHtml.Query as ElmHtmlQuery
 type Selector
     = All (List Selector)
     | Classes (List String)
-    | ClassesNS (List String)
     | Class String
-    | ClassNS String
     | Attribute { name : String, value : String }
     | BoolAttribute { name : String, value : Bool }
     | Style { key : String, value : String }
@@ -42,14 +40,8 @@ selectorToString criteria =
         Classes list ->
             "classes " ++ quoteString (String.join " " list)
 
-        ClassesNS list ->
-            "classesNS " ++ quoteString (String.join " " list)
-
         Class class ->
             "class " ++ quoteString class
-
-        ClassNS class ->
-            "classNS " ++ quoteString class
 
         Attribute { name, value } ->
             "attribute "
@@ -145,14 +137,8 @@ query fn fnAll selector list =
                 Classes classes ->
                     List.concatMap (fn (ElmHtmlQuery.ClassList classes)) elems
 
-                ClassesNS classes ->
-                    List.concatMap (fn (ElmHtmlQuery.ClassListNS classes)) elems
-
                 Class class ->
                     List.concatMap (fn (ElmHtmlQuery.ClassList [ class ])) elems
-
-                ClassNS class ->
-                    List.concatMap (fn (ElmHtmlQuery.ClassListNS [ class ])) elems
 
                 Attribute { name, value } ->
                     List.concatMap (fn (ElmHtmlQuery.Attribute name value)) elems

--- a/tests/src/Test/Html/SelectorTests.elm
+++ b/tests/src/Test/Html/SelectorTests.elm
@@ -18,8 +18,6 @@ all =
     describe "Test.Html.Selector"
         [ bug13
         , textSelectors
-        , classSelectors
-        , attributeSelectors
         , nsSelectors
         ]
 
@@ -27,7 +25,7 @@ all =
 nsSelectors : Test
 nsSelectors =
     describe "NS selectors"
-        [ test "classNS selector finds class on svg with one class" <|
+        [ test "class selector finds class on svg with one class" <|
             \() ->
                 let
                     svgClass =
@@ -37,8 +35,8 @@ nsSelectors =
                     [ SvgAttribs.class svgClass ]
                     [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
                     |> Query.fromHtml
-                    |> Query.has [ classNS svgClass ]
-        , test "classNS selector finds class on svg with multiple classes" <|
+                    |> Query.has [ class svgClass ]
+        , test "class selector finds class on svg with multiple classes" <|
             \() ->
                 let
                     svgClass =
@@ -48,8 +46,8 @@ nsSelectors =
                     [ SvgAttribs.class svgClass, SvgAttribs.class "another-NS-class" ]
                     [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
                     |> Query.fromHtml
-                    |> Query.has [ classNS svgClass ]
-        , test "classesNS selector finds all classes on svg" <|
+                    |> Query.has [ class svgClass ]
+        , test "classes selector finds all classes on svg" <|
             \() ->
                 let
                     svgClass =
@@ -59,8 +57,8 @@ nsSelectors =
                     [ SvgAttribs.class svgClass, SvgAttribs.class "another-NS-class" ]
                     [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
                     |> Query.fromHtml
-                    |> Query.has [ classesNS [ svgClass, "another-NS-class" ] ]
-        , test "classesNS selector finds single class on svg with multiple classes" <|
+                    |> Query.has [ classes [ svgClass, "another-NS-class" ] ]
+        , test "classes selector finds single class on svg with multiple classes" <|
             \() ->
                 let
                     svgClass =
@@ -70,52 +68,7 @@ nsSelectors =
                     [ SvgAttribs.class svgClass, SvgAttribs.class "another-NS-class" ]
                     [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
                     |> Query.fromHtml
-                    |> Query.has [ classesNS [ svgClass ] ]
-        , test "exactClassNameNS selector finds the exact class value on svg" <|
-            \() ->
-                let
-                    svgClass =
-                        "some-NS-class another-NS-class"
-                in
-                Svg.svg
-                    [ SvgAttribs.class svgClass ]
-                    [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
-                    |> Query.fromHtml
-                    |> Query.has [ exactClassNameNS svgClass ]
-        ]
-
-
-attributeSelectors : Test
-attributeSelectors =
-    describe "attribute selectors"
-        [ test "attribute selector does not find class on svg elements" <|
-            \() ->
-                let
-                    svgClass =
-                        "some-NS-class"
-                in
-                Svg.svg
-                    [ SvgAttribs.class svgClass ]
-                    [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
-                    |> Query.fromHtml
-                    |> Query.hasNot [ attribute (SvgAttribs.class svgClass) ]
-        ]
-
-
-classSelectors : Test
-classSelectors =
-    describe "class selectors"
-        [ test "does not find class on svg elements" <|
-            \() ->
-                let
-                    svgClass =
-                        "some-NS-class"
-                in
-                Svg.svg
-                    [ SvgAttribs.class svgClass ]
-                    [ Svg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
-                    |> Query.fromHtml
-                    |> Query.hasNot [ class svgClass ]
+                    |> Query.has [ classes [ svgClass ] ]
         ]
 
 


### PR DESCRIPTION
Updates Query to look at className and class properties/attributes, rather than relying only on the classNames.

Some context can be found in https://github.com/elm-explorations/test/pull/175#pullrequestreview-857523364